### PR TITLE
feat: implement word (jargon) `metatab` - First Iteration

### DIFF
--- a/src/layouts/word.astro
+++ b/src/layouts/word.astro
@@ -21,10 +21,10 @@ const editUrl = `/editor/edit/${frontmatter.url.split("/")[2]}`;
       <!-- Metatab -->
       <div class="flex mt-6 justify-between">
         <!-- WIP Meta Features -->
-        <div class="grow flex items-center space-x-2">
+        <!-- <div class="grow flex items-center space-x-2">
           <div class="w-10 h-10 bg-neutral-100 rounded-full" />
           <div class="w-2/5 h-3 bg-neutral-100 rounded-lg" />
-        </div>
+        </div> -->
         
         <!-- Edit Button -->
         <a href={editUrl}


### PR DESCRIPTION
This Pull Request implements the word (jargon) metatab; this is a tab that seats under the word title on the `word.astro` layout; It's a tab planned to hold the available interactive features/functions that can be performed on a word (jargon). This PR implements the first of this functions... see below... 

- The `Edit Word` Function - this is a button with a link to a jargons editor `edit`  word session for the specific word.

### Changes Made

- Implemented a boilerplate metatab div on the word layout with the following sections to start with
  - the WIP Feature section - a commented out placeholder divs to fantasize about the next features to implement on the metatab
  - the Edit word button - a link to the edit session for a word on the jargons editor, with `Suggest Improvements` as link text 
- Computed and Integrated the edit url for the `edit button` section of the metatab

### Screenshot

![image](https://github.com/babblebey/jargons.dev/assets/25631971/b2241354-252d-4cdb-8ba0-0ef05e5806da)

📖 