### PR TITLE
fix(jargons-editor): wrong pending contribution stats computation (#57)

### DIFF
--- a/src/lib/actions/do-contribution-stats.js
+++ b/src/lib/actions/do-contribution-stats.js
@@ -1,5 +1,6 @@
 import app from "../octokit/app.js";
 import { decrypt } from "../utils/crypto.js";
+import { buildStatsUrl } from "../utils/index.js";
 import { PROJECT_REPO_DETAILS } from "../../../constants.js";
 
 /**
@@ -30,7 +31,7 @@ export default async function doContributionStats(astroGlobal) {
     q: `${baseQuery} label:":book: edit word" is:merged is:closed`
   });
   const { data: pendingType } = await userOctokit.request("GET /search/issues", {
-    q: `${baseQuery} is:unmerged is:open`
+    q: `${baseQuery} label:":book: edit word",":book: new word" is:unmerged is:open`
   });
 
   return {
@@ -47,14 +48,4 @@ export default async function doContributionStats(astroGlobal) {
       url: buildStatsUrl(repoFullname, `${baseStatsUrlQuery} is:unmerged is:open`)
     }
   }
-}
-
-/**
- * Build URL to the Pull Request list on the project's Repo
- * @param {string} repoFullname 
- * @param {string} queryString 
- * @returns {string}
- */
-function buildStatsUrl(repoFullname, queryString) {
-  return `https://github.com/${repoFullname}/pulls?q=${encodeURIComponent(queryString)}`;
 }

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -68,3 +68,13 @@ export function capitalizeText(text) {
 export function generateBranchName(action, wordTitle) {
   return `word/${action}/${normalizeAsUrl(wordTitle)}`;
 }
+
+/**
+ * Build URL to the Pull Request list on the project's Repo
+ * @param {string} repoFullname 
+ * @param {string} queryString 
+ * @returns {string}
+ */
+export function buildStatsUrl(repoFullname, queryString) {
+  return `https://github.com/${repoFullname}/pulls?q=${encodeURIComponent(queryString)}`;
+}

--- a/src/pages/editor/index.astro
+++ b/src/pages/editor/index.astro
@@ -3,6 +3,7 @@ import { Image } from "astro:assets";
 import BaseLayout from "../../layouts/base.astro";
 import doAuth from "../../lib/actions/do-auth.js";
 import Navbar from "../../components/navbar.astro";
+import { buildStatsUrl } from "../../lib/utils/index.js";
 import { PROJECT_REPO_DETAILS } from "../../../constants.js";
 import doContributionStats from "../../lib/actions/do-contribution-stats.js";
 
@@ -14,7 +15,10 @@ if (!isAuthed) return redirect(`/login?return_to=${encodeURIComponent(pathname)}
 const { newWords, editedWords, pendingWords } = await doContributionStats(Astro);
 const totalWords = {
   count: newWords.count + editedWords.count,
-  url: `https://github.com/${PROJECT_REPO_DETAILS.repoFullname}/pulls?q=${encodeURIComponent(`is:pr is:closed is:merged author:@me`)}`
+  url: buildStatsUrl(
+    PROJECT_REPO_DETAILS.repoFullname, 
+    `label:":book: edit word",":book: new word" is:pr is:closed is:merged author:@me`
+  )
 }
 ---
 


### PR DESCRIPTION
This Pull request fixes the issue where all Pull Requests are considered in the computation of pending word contribution; this was because of a missing imperative labels i.e. `📖 new word` and `📖 edit word` which should've been used to within the search request filter to narrow down list of PRs returns by checking for the presence of either of both label in opened pull requests on the jargons.dev repo.

### Changes Made

- Added missing labels `label:":book: edit word",":book: new word"` to the `pendingType` pull search as filter that check for the presence of either label
- Extracted `buildStatsUrl` to utils  from `doContributionStats` action
- Added the same missing labels `label:":book: edit word",":book: new word"` to the `buildStatsUrl` execution queryString param for the computation of `totalWords` stats url

### Screencast

https://github.com/babblebey/jargons.dev/assets/25631971/1db9a614-8432-466b-a234-44693b2253d5

📖