### PR TITLE
Dictionary (New Word): XSLT

### DIFF
--- a/src/content/dictionary/xslt.mdx
+++ b/src/content/dictionary/xslt.mdx
@@ -1,0 +1,7 @@
+---
+layout: ../../layouts/word.astro
+title: "XSLT"
+---
+eXtensible Stylesheet Language Transformations (XSLT) is a declarative language used to convert XML documents into other XML documents, HTML, PDF, plain text, and so on.
+
+XSLT has its own processor that accepts XML input, or any format convertible to an XQuery and XPath Data Model. The XSLT processor produces a new document based on the XML document and an XSLT stylesheet, making no changes to the original files in the process.


### PR DESCRIPTION
# Word

#### XSLT

# Meaning/Definition

eXtensible Stylesheet Language Transformations (XSLT) is a declarative language used to convert XML documents into other XML documents, HTML, PDF, plain text, and so on.

XSLT has its own processor that accepts XML input, or any format convertible to an XQuery and XPath Data Model. The XSLT processor produces a new document based on the XML document and an XSLT stylesheet, making no changes to the original files in the process.