### PR TITLE
fix(accessibility): Add descriptive title to GitHub button iframe

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,7 +28,7 @@ const dictionary = await getCollection("dictionary");
         scrolling="0"
         width="120"
         height="30"
-        title="GitHub"
+        title="Star jargons.dev on GitHub"
       >
       </iframe>
     </div>


### PR DESCRIPTION
Improves accessibility by adding a title attribute to the GitHub button iframe.

## Description
This adds a descriptive title attribute to the GitHub button iframe to improve accessibility.
Fixes issue #211


## Related Issue
Fixes #211


## Screenshots/Screencasts
<img width="887" height="343" alt="Screenshot 2025-10-18 131616" src="https://github.com/user-attachments/assets/d92b72e3-f79b-4737-a2f3-b1ff77542345" />



## Notes to Reviewer
<!-- Please state here if you added a new npm packages, or any extra information that can help reviewer better review you changes -->

