### PR TITLE
Make navbar logo link to homepage for improved navigation

### DIFF
--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -29,7 +29,9 @@ const { returnNav = { label: "Back", location: "../" } } = Astro.props;
         {returnNav.label}
       </span>
     </a>
-    <JargonsdevLogo class="drop-shadow drop-shadow-color-black h-10 md:h-12" />
+    <a href="/" class="block">
+  <JargonsdevLogo class="drop-shadow drop-shadow-color-black h-10 md:h-12" />
+</a>
   </div>
   <slot />
 </nav>


### PR DESCRIPTION
## Make navbar logo link to homepage for improved navigation

This change wraps the `JargonsdevLogo` component in a link (`<a href="/">`) so users can click the logo to return to the homepage.

**Fixes #243**

### Summary
- Wrapped the logo component with an anchor tag linking to `/`
- Ensures the logo remains visually identical (size, drop shadow, layout)
- Improves accessibility and follows standard web navigation conventions

### Files Modified
- `src/components/navbar.astro`

### Testing Checklist
- [x] Logo is clickable and links to the homepage (`/`)
- [x] Styling and layout remain unchanged
- [x] Link works from all pages

---

Enhances user experience by providing an intuitive way to navigate back to the main page.
